### PR TITLE
fix(menubutton): メニューボタンのレイアウト崩れを修正

### DIFF
--- a/src/components/atoms/ConfigMenu/MenuButton/MenuButton.scss
+++ b/src/components/atoms/ConfigMenu/MenuButton/MenuButton.scss
@@ -2,7 +2,7 @@
 .button-dots-vertical {
   @include smart-svg.show-with-pseudo(
     'dots-vertical.svg',
-    1.5rem,
+    3rem,
     $fill-color: theme('colors.white')
   );
 }

--- a/src/components/atoms/ConfigMenu/MenuButton/MenuButton.tsx
+++ b/src/components/atoms/ConfigMenu/MenuButton/MenuButton.tsx
@@ -11,12 +11,16 @@ export default function MenuButton({
   onClick: () => void;
 }) {
   const className = useMemo(
-    () => clsx('rounded-full h-6 w-6 px-0', _className),
+    () => clsx('rounded-full h-12 w-12 flex', _className),
     [_className],
   );
   return (
-    <Button onClick={onClick} className={className}>
-      <span className="button-dots-vertical"></span>
+    <Button
+      onClick={onClick}
+      className={className}
+      style={{ borderRadius: '9999px' }}
+    >
+      <div className="button-dots-vertical"></div>
     </Button>
   );
 }

--- a/src/components/atoms/ConfigMenu/MenuStack/MenuStack.scss
+++ b/src/components/atoms/ConfigMenu/MenuStack/MenuStack.scss
@@ -2,14 +2,14 @@
 .svg-checked {
   @include smart-svg.show-with-pseudo(
     'check.svg',
-    1rem,
+    1.2rem,
     $fill-color: theme('colors.zinc.600')
   );
 }
 .svg-unchecked {
   @include smart-svg.show-with-pseudo(
     'check.svg',
-    1rem,
+    1.2rem,
     $fill-color: theme('colors.transparent')
   );
 }

--- a/src/components/atoms/ConfigMenu/MenuStack/MenuStack.tsx
+++ b/src/components/atoms/ConfigMenu/MenuStack/MenuStack.tsx
@@ -32,18 +32,27 @@ export default function MenuStack({
     [variant],
   );
   const containerClass = useMemo(
-    () => clsx(className, 'shadow border-zinc-500 rounded p-2 bg-zinc-50'),
+    () =>
+      clsx(className, 'shadow border-zinc-500 rounded p-2 bg-zinc-50 flex-col'),
     [className],
   );
   return (
     <div
       className={containerClass}
-      style={{ display: isShow ? 'block' : 'none' }}
+      style={{ display: isShow ? 'flex' : 'none' }}
     >
-      <Button className="text-base block" variant="text" onClick={onSelectNum}>
+      <Button
+        className="block text-xl w-full text-left"
+        variant="text"
+        onClick={onSelectNum}
+      >
         <span className={numClass}></span>数字で遊ぶ
       </Button>
-      <Button className="text-base block" variant="text" onClick={onSelectIcon}>
+      <Button
+        className="block text-xl w-full text-left"
+        variant="text"
+        onClick={onSelectIcon}
+      >
         <span className={iconClass}></span>アイコンで遊ぶ
       </Button>
     </div>

--- a/src/components/atoms/ConfigMenu/index.tsx
+++ b/src/components/atoms/ConfigMenu/index.tsx
@@ -9,7 +9,7 @@ export default function ConfigMenu() {
       <MenuStack
         isShow={isShowConfig}
         onSelected={() => showConfig(false)}
-        className="fixed bottom-4 right-12"
+        className="fixed bottom-4 right-16"
       ></MenuStack>
       <MenuButton
         onClick={() => showConfig(!isShowConfig)}


### PR DESCRIPTION
tailwind のアップデーㇳでデザインが崩れたので修正。ついでに大きくした。

before | after
--|--
![image](https://github.com/ysk8hori/numberplace/assets/5052869/1e7555d1-f04b-4441-84c9-b3c9a63ae8f9) | ![image](https://github.com/ysk8hori/numberplace/assets/5052869/644b4f4f-f8eb-4e2b-8729-9a105f52b013)

