### PR TITLE
feat: build を可能とする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sentry/react": "7.119.0",
         "@sentry/tracing": "7.114.0",
         "@tanstack/react-query": "5.56.2",
-        "@ysk8/numberplace-generator": "npm:@jsr/ysk8__numberplace-generator@4.0.0-alpha.8",
+        "@ysk8/numberplace-generator": "npm:@jsr/ysk8__numberplace-generator@4.0.0-alpha.9",
         "@ysk8hori/numberplace-generator": "3.0.2",
         "clsx": "2.1.1",
         "react": "18.3.1",
@@ -11251,9 +11251,9 @@
     },
     "node_modules/@ysk8/numberplace-generator": {
       "name": "@jsr/ysk8__numberplace-generator",
-      "version": "4.0.0-alpha.8",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/ysk8__numberplace-generator/4.0.0-alpha.8.tgz",
-      "integrity": "sha512-aUIbiJ4YU3ld7asKKRMa/lUettJ9Lk8tf9EhuNhcc0HfA/O7nJX7jF+Dd1Sx+t7ipU5mOskUBgbDlB2PhEvEmA==",
+      "version": "4.0.0-alpha.9",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/ysk8__numberplace-generator/4.0.0-alpha.9.tgz",
+      "integrity": "sha512-sgTTgaZ+TS1YwgORSsdBwvXcOuzHfqC3EOZne04BpErQm8xUkuLwoehaUniq/R3QzYq+NVmSZoWTkSDAEyJwIQ==",
       "dependencies": {
         "remeda": "^2.12.0"
       }
@@ -36082,9 +36082,9 @@
       }
     },
     "@ysk8/numberplace-generator": {
-      "version": "npm:@jsr/ysk8__numberplace-generator@4.0.0-alpha.8",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/ysk8__numberplace-generator/4.0.0-alpha.8.tgz",
-      "integrity": "sha512-aUIbiJ4YU3ld7asKKRMa/lUettJ9Lk8tf9EhuNhcc0HfA/O7nJX7jF+Dd1Sx+t7ipU5mOskUBgbDlB2PhEvEmA==",
+      "version": "npm:@jsr/ysk8__numberplace-generator@4.0.0-alpha.9",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/ysk8__numberplace-generator/4.0.0-alpha.9.tgz",
+      "integrity": "sha512-sgTTgaZ+TS1YwgORSsdBwvXcOuzHfqC3EOZne04BpErQm8xUkuLwoehaUniq/R3QzYq+NVmSZoWTkSDAEyJwIQ==",
       "requires": {
         "remeda": "^2.12.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@sentry/react": "7.119.0",
     "@sentry/tracing": "7.114.0",
     "@tanstack/react-query": "5.56.2",
-    "@ysk8/numberplace-generator": "npm:@jsr/ysk8__numberplace-generator@4.0.0-alpha.8",
+    "@ysk8/numberplace-generator": "npm:@jsr/ysk8__numberplace-generator@4.0.0-alpha.9",
     "@ysk8hori/numberplace-generator": "3.0.2",
     "clsx": "2.1.1",
     "react": "18.3.1",


### PR DESCRIPTION
新しいジェネレータのデバッグコードに top level await があり build において vite-plugin-pwa がエラーになっていた。 そのためジェネレータから top level await をなくした。