### PR TITLE
renovate の設定を変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,10 @@
 {
-  "extends": ["config:base"],
-  "baseBranches": ["develop"],
+  "extends": ["config:recommended"],
+  "baseBranches": ["main"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["after 5pm and before 10pm"],
+  "schedule": ["after 5pm and before 10pm on Thursday"],
+  "minimumReleaseAge": "7 days",
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor"],


### PR DESCRIPTION
- 特にセキュリティリスク回避のためパッケージ公開から1週間たったもののみ取り込む