### PR TITLE
fix: include wasm in pwa precache

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       },
       registerType: 'autoUpdate',
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,ttf}'],
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,ttf,wasm}'],
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- include `.wasm` in the PWA Workbox precache glob patterns
- prevent runtime fetch miss of wasm asset in production clients that rely on service worker cache

## Testing
- pnpm run check
- pnpm run build
